### PR TITLE
Fixes nukebuild on systems with different culture

### DIFF
--- a/nukebuild/BuildScripts.cs
+++ b/nukebuild/BuildScripts.cs
@@ -539,7 +539,7 @@ public sealed partial class Build
     private double ParseFloat(string value)
     {
         // First try regular values like "40" and "40.0"
-        if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out double dec))
+        if (double.TryParse(value, NumberStyles.AllowDecimalPoint, _enUS, out double dec))
         {
             return dec;
         }

--- a/nukebuild/BuildScripts.cs
+++ b/nukebuild/BuildScripts.cs
@@ -539,7 +539,7 @@ public sealed partial class Build
     private double ParseFloat(string value)
     {
         // First try regular values like "40" and "40.0"
-        if (double.TryParse(value, out double dec))
+        if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out double dec))
         {
             return dec;
         }

--- a/nukebuild/global.json
+++ b/nukebuild/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
Fixes issue where number parsing causes build to fail on systems that have culture with different non-standard decimal separator

Fixes issue where latest installed dotnet version would be used (for example, a preview version), instead of net6.0